### PR TITLE
Task: Initialise Gem Distribution

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,49 @@
+#!/bin/sh
+# caveat: this script assumes all modifications to a file were staged in the commit
+# beware if you are in the habit of committing only partial modifications to a file:
+# THIS HOOK WILL ADD ALL MODIFICATIONS TO A FILE TO THE COMMIT IF ANY FILE WAS CHANGED BY LINTING
+
+list="issue spike task"
+
+listRE="^($(printf '%s\n' "$list" | tr ' ' '|'))/"
+
+BRANCH_NAME=$(git branch --show-current | grep -E "$listRE" | sed 's/* //')
+
+printf '\n\033[0;105mChecking "%s"... \033[0m\n', "$BRANCH_NAME"
+
+if echo "$BRANCH_NAME" | grep -q '^(rebase)|(production)*$'; then
+ 	printf '\n\033[0;32mNo checks necessary on "%s", pushing now... 🎉\033[0m\n', "$BRANCH_NAME"
+	exit 0
+fi
+
+RUBY_FILES="$(git diff --diff-filter=d --name-only --cached | grep -E '(Gemfile|Rakefile|\.(rb|rake|ru))$')"
+PRE_STATUS="$(git status | wc -l)"
+WORK_DONE=0
+
+if [ -n "$RUBY_FILES" ]; then
+  printf '\nRunning Rubocop...'
+  bundle exec rubocop --autocorrect "$RUBY_FILES"
+  RUBOCOP_EXIT_CODE=$?
+  WORK_DONE=1
+else
+  printf '\nNo changed files, Rubocop linting not needed ...'
+  RUBOCOP_EXIT_CODE=0
+fi
+
+POST_STATUS="$(git status | wc -l)"
+
+if [ ! $RUBOCOP_EXIT_CODE -eq 0 ]; then
+  git reset HEAD
+  printf '\n\033[0;31mLinting has uncorrectable errors; please fix and restage your commit. 😖\033[0m\n'
+  exit 1
+fi
+
+if [ "$PRE_STATUS" != "$POST_STATUS" ]; then
+  git add "$RUBY_FILES"
+fi
+
+if [ $WORK_DONE -eq 1 ]; then
+  printf '\n\033[0;32mLinting completed successfully! 🎉\033[0m\n'
+fi
+
+exit 0

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -18,7 +18,25 @@ fi
 
 RUBY_FILES="$(git diff --diff-filter=d --name-only --cached | grep -E '(Gemfile|Rakefile|\.(rb|rake|ru))$')"
 PRE_STATUS="$(git status | wc -l)"
+
 WORK_DONE=0
+
+if [ -z "$RUBY_FILES" ]; then
+  printf 'There are currently no updated files in "%s".\n', "$BRANCH_NAME"
+	# while true; do
+  #   read -r "Are you sure you want to continue (y/n)?" yn
+  #   case $yn in
+  #     [Yy]* )
+  #       printf '\n\033[0;31mContinuing without any new changes... 😖\033[0m\n'
+  #       break;;
+  #     [Nn]* )
+  #       printf '\n\033[0;32mExiting now to allow changes to be made... 🎉\033[0m\n'
+  #       exit 1;;
+  #     * ) echo "Please answer yes or no.";;
+  #   esac
+	# done
+fi
+
 
 if [ -n "$RUBY_FILES" ]; then
   printf '\nRunning Rubocop...'
@@ -26,7 +44,6 @@ if [ -n "$RUBY_FILES" ]; then
   RUBOCOP_EXIT_CODE=$?
   WORK_DONE=1
 else
-  printf '\nNo changed files, Rubocop linting not needed ...'
   RUBOCOP_EXIT_CODE=0
 fi
 

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -9,10 +9,10 @@ listRE="^($(printf '%s\n' "$list" | tr ' ' '|'))/"
 
 BRANCH_NAME=$(git branch --show-current | grep -E "$listRE" | sed 's/* //')
 
-printf '\n\033[0;105mChecking "%s"... \033[0m\n', "$BRANCH_NAME"
+printf '\n\033[0;105mChecking "%s"... \033[0m\n' "$BRANCH_NAME"
 
 if echo "$BRANCH_NAME" | grep -q '^(rebase)|(production)*$'; then
- 	printf '\n\033[0;32mNo checks necessary on "%s", pushing now... 🎉\033[0m\n', "$BRANCH_NAME"
+ 	printf '\n\033[0;32mNo checks necessary on "%s", pushing now... 🎉\033[0m\n' "$BRANCH_NAME"
 	exit 0
 fi
 
@@ -22,7 +22,7 @@ PRE_STATUS="$(git status | wc -l)"
 WORK_DONE=0
 
 if [ -z "$RUBY_FILES" ]; then
-  printf '\n\033[0;41mThere are currently no updated files in "%s". 🤨\033[0m\n', "$BRANCH_NAME"
+  printf '\n\033[0;31mThere are currently no updated files in "%s". 🤨\033[0m\n' "$BRANCH_NAME"
 fi
 
 

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -22,24 +22,12 @@ PRE_STATUS="$(git status | wc -l)"
 WORK_DONE=0
 
 if [ -z "$RUBY_FILES" ]; then
-  printf 'There are currently no updated files in "%s".\n', "$BRANCH_NAME"
-	# while true; do
-  #   read -r "Are you sure you want to continue (y/n)?" yn
-  #   case $yn in
-  #     [Yy]* )
-  #       printf '\n\033[0;31mContinuing without any new changes... 😖\033[0m\n'
-  #       break;;
-  #     [Nn]* )
-  #       printf '\n\033[0;32mExiting now to allow changes to be made... 🎉\033[0m\n'
-  #       exit 1;;
-  #     * ) echo "Please answer yes or no.";;
-  #   esac
-	# done
+  printf '\n\033[0;41mThere are currently no updated files in "%s". 🤨\033[0m\n', "$BRANCH_NAME"
 fi
 
 
 if [ -n "$RUBY_FILES" ]; then
-  printf '\n\033[0;31mRunning Rubocop...\033[0m\n'
+  printf '\n\033[0;33mRunning Rubocop...\033[0m\n'
   bundle exec rubocop --autocorrect "$RUBY_FILES"
   RUBOCOP_EXIT_CODE=$?
   WORK_DONE=1

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -39,11 +39,12 @@ fi
 
 
 if [ -n "$RUBY_FILES" ]; then
-  printf '\nRunning Rubocop...'
+  printf '\n\033[0;31mRunning Rubocop...\033[0m\n'
   bundle exec rubocop --autocorrect "$RUBY_FILES"
   RUBOCOP_EXIT_CODE=$?
   WORK_DONE=1
 else
+  printf '\n\033[0;32mContinuing as there are no changes to check... 🎉\033[0m\n'
   RUBOCOP_EXIT_CODE=0
 fi
 

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -22,8 +22,17 @@ WORK_DONE=0
 
 if [ -z "$TEST_FILES" ]; then
   printf '\n\033[0;31mThere are currently no new tests found in "%s". 🤨\033[0m\n' "$BRANCH_NAME"
-  printf '\n\033[0;32mExiting now to allow tests to be added... 🎉\033[0m\n'
-  exit 1
+  while true ; do
+    read -rp 'Are you sure you want to continue (y/n)? ' RESPONSE
+    case $RESPONSE in
+      [Yy]* )
+        printf '\n\033[0;31mContinuing without new tests... 😖\033[0m\n'
+        break;;
+      [Nn]* )
+        printf '\n\033[0;32mExiting now to allow tests to be added... 🎉\033[0m\n'
+        exit 1;;
+    esac
+  done
 fi
 
 

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -6,7 +6,7 @@ listRE="^($(printf '%s\n' "$list" | tr ' ' '|'))/"
 
 BRANCH_NAME=$(git branch --show-current | grep -E "$listRE" | sed 's/* //')
 
-printf '\n\033[0;105mChecking "%s"... \033[0m\n', "$BRANCH_NAME"
+printf '\n\033[0;105mChecking "%s"... \033[0m\n' "$BRANCH_NAME"
 
 if echo "$BRANCH_NAME" | grep -q '^(rebase)|(production)*$'; then
  	printf '\n\033[0;32mNo checks necessary on "%s", pushing now... 🎉\033[0m\n' "$BRANCH_NAME"
@@ -24,7 +24,6 @@ if [ -z "$TEST_FILES" ]; then
   printf '\n\033[0;31mThere are currently no new tests found in "%s". 🤨\033[0m\n' "$BRANCH_NAME"
   while true; do
     read -p 'Are you sure you want to continue (y/n)? ' -n 1 -r RESPONSE
-    echo
     case $RESPONSE in
       [Yy]* )
         printf '\n\033[0;31mContinuing without new tests... 😖\033[0m\n'
@@ -34,6 +33,7 @@ if [ -z "$TEST_FILES" ]; then
         exit 1;;
     esac
   done
+  echo
 fi
 
 

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -22,18 +22,18 @@ WORK_DONE=0
 
 if [ -z "$TEST_FILES" ]; then
   printf '\n\033[0;31mThere are currently no new tests found in "%s". 🤨\033[0m\n' "$BRANCH_NAME"
-  while true; do
-    read -p 'Are you sure you want to continue (y/n)? ' -n 1 -r RESPONSE
-    case $RESPONSE in
-      [Yy]* )
+  # while true; do
+  #   read -p 'Are you sure you want to continue (y/n)? ' -n 1 -r RESPONSE
+  #   case $RESPONSE in
+  #     [Yy]* )
         printf '\n\033[0;31mContinuing without new tests... 😖\033[0m\n'
-        break;;
-      [Nn]* )
-        printf '\n\033[0;32mExiting now to allow tests to be added... 🎉\033[0m\n'
-        exit 1;;
-    esac
-  done
-  echo
+  #       break;;
+  #     [Nn]* )
+  #       printf '\n\033[0;32mExiting now to allow tests to be added... 🎉\033[0m\n'
+  #       exit 1;;
+  #   esac
+  # done
+  # echo
 fi
 
 

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -9,7 +9,7 @@ BRANCH_NAME=$(git branch --show-current | grep -E "$listRE" | sed 's/* //')
 printf '\n\033[0;105mChecking "%s"... \033[0m\n', "$BRANCH_NAME"
 
 if echo "$BRANCH_NAME" | grep -q '^(rebase)|(production)*$'; then
- 	printf '\n\033[0;32mNo checks necessary on "%s", pushing now... 🎉\033[0m\n', "$BRANCH_NAME"
+ 	printf '\n\033[0;32mNo checks necessary on "%s", pushing now... 🎉\033[0m\n' "$BRANCH_NAME"
 	exit 0
 fi
 
@@ -21,7 +21,7 @@ PRE_STATUS="$(git status | wc -l)"
 WORK_DONE=0
 
 if [ -z "$TEST_FILES" ]; then
-  printf '\n\033[0;41mThere are currently no new tests found in "%s". 🤨\033[0m\n', "$BRANCH_NAME"
+  printf '\n\033[0;31mThere are currently no new tests found in "%s". 🤨\033[0m\n' "$BRANCH_NAME"
   printf '\n\033[0;32mExiting now to allow tests to be added... 🎉\033[0m\n'
   exit 1
 fi

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -22,8 +22,9 @@ WORK_DONE=0
 
 if [ -z "$TEST_FILES" ]; then
   printf '\n\033[0;31mThere are currently no new tests found in "%s". 🤨\033[0m\n' "$BRANCH_NAME"
-  while true ; do
-    read -rp 'Are you sure you want to continue (y/n)? ' RESPONSE
+  while true; do
+    read -p 'Are you sure you want to continue (y/n)? ' -n 1 -r RESPONSE
+    echo
     case $RESPONSE in
       [Yy]* )
         printf '\n\033[0;31mContinuing without new tests... 😖\033[0m\n'

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,0 +1,58 @@
+#!/bin/bash
+
+list="issue spike task"
+
+listRE="^($(printf '%s\n' "$list" | tr ' ' '|'))/"
+
+BRANCH_NAME=$(git branch --show-current | grep -E "$listRE" | sed 's/* //')
+
+printf '\n\033[0;105mChecking "%s"... \033[0m\n', "$BRANCH_NAME"
+
+if echo "$BRANCH_NAME" | grep -q '^(rebase)|(production)*$'; then
+ 	printf '\n\033[0;32mNo checks necessary on "%s", pushing now... 🎉\033[0m\n', "$BRANCH_NAME"
+	exit 0
+fi
+
+# Check for existence of "new or modified" test files
+TEST_FILES="$(git diff --diff-filter=ACDM --name-only --cached | grep -E '(./test/*)$')"
+RUBY_FILES="$(git diff --diff-filter=ACDM --name-only --cached | grep -E '(_test\.rb)$')"
+PRE_STATUS="$(git status | wc -l)"
+
+WORK_DONE=0
+
+if [ -z "$TEST_FILES" ]; then
+  printf '\n\033[0;41mThere are currently no new tests found in "%s". 🤨\033[0m\n', "$BRANCH_NAME"
+  printf '\n\033[0;32mExiting now to allow tests to be added... 🎉\033[0m\n'
+  exit 1
+fi
+
+
+if [ -n "$RUBY_FILES" ]; then
+  printf '\nRunning Rails Tests...'
+  bundle exec rails test
+  RUBY_TEST_EXIT_CODE=$?
+  WORK_DONE=1
+else
+  RUBY_TEST_EXIT_CODE=0
+fi
+
+if [ -n "$RUBY_FILES" ]; then
+  printf '\nRunning System Tests...'
+  bundle exec rails test:system
+  RUBY_SYSTEM_EXIT_CODE=$?
+  WORK_DONE=1
+else
+  RUBY_SYSTEM_EXIT_CODE=0
+fi
+
+
+if [ ! $RUBY_TEST_EXIT_CODE -eq 0 ] || [ ! $RUBY_SYSTEM_EXIT_CODE -eq 0 ]; then
+  printf '\n\033[0;31mCannot push, tests are failing. Use --no-verify to force push. 😖\033[0m\n'
+  exit 1
+fi
+
+if [ $WORK_DONE = 1 ]; then
+  printf '\n\033[0;32mAll tests are green, pushing... 🎉\033[0m\n'
+fi
+
+exit 0

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,45 @@
+name: Release and Publish Gem
+on:
+  workflow_dispatch: {}
+
+env:
+  GEM_NAME: qonsole-rails
+
+#---- Below this line should not require editing ----
+jobs:
+  build:
+    name: "Build gem package"
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+
+    - name: "Git Information"
+      id: gitinfo
+      run: |
+        echo name=${GITHUB_REF#refs/*/}       | tee -a $GITHUB_OUTPUT
+        echo branch=${GITHUB_REF#refs/heads/} | tee -a $GITHUB_OUTPUT
+        make tags                             | tee -a $GITHUB_OUTPUT
+
+    - name: "Build gem"
+      run: "make gem"
+
+    - name: "Create Release"
+      id: release
+      uses: softprops/action-gh-release@v2
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        tag_name: ${{ steps.gitinfo.outputs.version }}
+        name: v${{ steps.gitinfo.outputs.version }}
+        generate_release_notes: true
+        draft: false
+        prerelease: false
+        files: |
+          $GEM_NAME-${{ steps.gitinfo.outputs.version }}.gem
+
+    - name: "Publish gem"
+      run: |
+        PAT=${{ secrets.GITHUB_TOKEN }} make publish

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -1,0 +1,37 @@
+name: Unit Tests
+
+on:
+  pull_request:
+    types:
+      - closed
+    branches:
+      - 'master'
+
+jobs:
+  test:
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: "Record desired ruby version"
+        id: ruby
+        shell: bash
+        run: |
+          [ -f .ruby-version ] && echo version=$(cat .ruby-version) | tee -a $GITHUB_OUTPUT ||  echo "version=" >> $GITHUB_OUTPUT
+
+      - name: "Setup ruby"
+        if:  steps.ruby.outputs.version != ''
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ steps.ruby.outputs.version }}
+
+      - name: Install dependencies (bundle)
+        run: bundle install
+
+      - name: Run checks
+        run: |
+          PAT=${{ secrets.EPI_GPR_READ_ACCESS_TOKEN }} make lint test

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,16 +1,37 @@
 require: rubocop-rails
-Metrics/LineLength:
-  Max: 100
-Style/FrozenStringLiteralComment:
-  Enabled: false
-Rails:
-  Enabled: true
-Metrics/BlockLength:
-  Exclude:
-    - 'test/**/*.rb'
+
 AllCops:
+  NewCops: enable
   Exclude:
     - 'test/dummy/**/*'
     - 'bin/*'
+
+# https://docs.rubocop.org/rubocop/cops_gemspec.html#enforcedstyle_-forbidden-gemspecdependencyversion
+# Enforce that gem dependency version specifications or a commit reference
+# (branch, ref, or tag) are either required or forbidden.
+Gemspec/DependencyVersion:
+  EnforcedStyle: forbidden
+
+Layout/LineLength:
+  Max: 100
+  Exclude:
+    - qonsole_rails.gemspec
+    - 'test/**/*'
+
+Metrics/BlockLength:
+  Exclude:
+    - qonsole_rails.gemspec
+    - 'test/**/*'
+
+Rails:
+  Enabled: true
+
+Style/Documentation:
+  Exclude:
+    - 'test/**/*'
+
+Style/FrozenStringLiteralComment:
+  Enabled: false
+
 Style/TrivialAccessors:
   IgnoreClassMethods: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,14 @@
 Qonsole Rails is a Ruby-on-Rails engine for embedding the ability to display,
 edit and run SPARQL queries in a larger Rails app.
 
+# 2.1.0 - 2025-02
+
+- Added gem creation and publishing workflows for easier updates.
+- Updated rubocop rules for better readability and style.
+- Adjusted gemspec to meet new guidelines from rubocop linting.
+- Implemented pre-commit and pre-push githooks for linting/testing.
+- Revamped README with the latest info on the gem and publishing process.
+
 ## 2.0.0 - 2025-01
 
 - Updated the error handling for the qonsole gem by ensuring that the proper

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -12,6 +12,8 @@ PATH
       lodash-rails
       modulejs-rails
       rails
+      rubocop
+      rubocop-rails
 
 GEM
   remote: https://rubygems.org/
@@ -87,6 +89,7 @@ GEM
       minitest (>= 5.1)
       securerandom (>= 0.3)
       tzinfo (~> 2.0, >= 2.0.5)
+    ast (2.4.2)
     base64 (0.2.0)
     benchmark (0.4.0)
     bigdecimal (3.1.9)
@@ -163,6 +166,8 @@ GEM
       rails-dom-testing (>= 1, < 3)
       railties (>= 4.2.0)
       thor (>= 0.14, < 2.0)
+    json (2.9.1)
+    language_server-protocol (3.17.0.4)
     lodash-rails (4.17.21)
       railties (>= 3.1)
     logger (1.6.5)
@@ -216,6 +221,10 @@ GEM
       racc (~> 1.4)
     nokogiri (1.18.2-x86_64-linux-musl)
       racc (~> 1.4)
+    parallel (1.26.3)
+    parser (3.3.7.0)
+      ast (~> 2.4.1)
+      racc
     psych (5.1.2)
       stringio
     racc (1.8.1)
@@ -257,11 +266,31 @@ GEM
       rake (>= 12.2)
       thor (~> 1.0, >= 1.2.2)
       zeitwerk (~> 2.6)
+    rainbow (3.1.1)
     rake (13.2.1)
     rdoc (6.7.0)
       psych (>= 4.0.0)
+    regexp_parser (2.10.0)
     reline (0.5.10)
       io-console (~> 0.5)
+    rubocop (1.71.2)
+      json (~> 2.3)
+      language_server-protocol (>= 3.17.0)
+      parallel (~> 1.10)
+      parser (>= 3.3.0.2)
+      rainbow (>= 2.2.2, < 4.0)
+      regexp_parser (>= 2.9.3, < 3.0)
+      rubocop-ast (>= 1.38.0, < 2.0)
+      ruby-progressbar (~> 1.7)
+      unicode-display_width (>= 2.4.0, < 4.0)
+    rubocop-ast (1.38.0)
+      parser (>= 3.3.1.0)
+    rubocop-rails (2.29.1)
+      activesupport (>= 4.2.0)
+      rack (>= 1.1)
+      rubocop (>= 1.52.0, < 2.0)
+      rubocop-ast (>= 1.31.1, < 2.0)
+    ruby-progressbar (1.13.0)
     ruby2_keywords (0.0.5)
     sass-rails (6.0.0)
       sassc-rails (~> 2.1, >= 2.1.1)
@@ -288,6 +317,9 @@ GEM
     timeout (0.4.1)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
+    unicode-display_width (3.1.4)
+      unicode-emoji (~> 4.0, >= 4.0.4)
+    unicode-emoji (4.0.4)
     useragent (0.16.11)
     webrick (1.8.2)
     websocket-driver (0.7.6)

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,61 @@
+.PHONY: auth clean gem publish test vars
+
+NAME?=qonsole_rails
+OWNER?=epimorphics
+VERSION?=$(shell /usr/bin/env ruby -e 'require "./lib/${NAME}/version" ; puts QonsoleRails::VERSION')
+PAT?=$(shell read -p 'Github access token:' TOKEN; echo $$TOKEN)
+
+AUTH=${HOME}/.gem/credentials
+GEM=${NAME}-${VERSION}.gem
+GPR=https://rubygems.pkg.github.com/${OWNER}
+SPEC=${NAME}.gemspec
+
+all: publish
+
+${AUTH}:
+	@mkdir -p ${HOME}/.gem
+	@echo '---' > ${AUTH}
+	@echo ':github: Bearer ${PAT}' >> ${AUTH}
+	@chmod 0600 ${AUTH}
+
+${GEM}: ${SPEC} ./lib/${NAME}/version.rb
+	gem build ${SPEC}
+
+auth: ${AUTH}
+
+build: gem
+
+clean:
+	@rm -rf ${GEM}
+
+gem: ${GEM}
+	@echo ${GEM}
+
+lint:
+	@bundle install
+	@echo "Running rubocop..."
+	@bundle exec rubocop
+
+publish: ${AUTH} ${GEM}
+	@echo Publishing package ${NAME}:${VERSION} to ${OWNER} ...
+	@gem push --key github --host ${GPR} ${GEM}
+	@echo Done.
+
+realclean: clean
+	@rm -rf ${AUTH}
+
+tags:
+	@echo version=${VERSION}
+
+test:
+	@bundle install
+	@bundle exec rake test
+
+vars:
+	@echo "GEM"	= ${GEM}
+	@echo "GPR"	= ${GPR}
+	@echo "NAME = ${NAME}"
+	@echo "OWNER = ${OWNER}"
+	@echo "SPEC = ${SPEC}"
+	@echo "VERSION = ${VERSION}"
+

--- a/README.md
+++ b/README.md
@@ -1,17 +1,50 @@
 # qonsole-rails
 
-**_Warning: While this project has not yet been replaced and should continue to receive required bug fixes and any minor feature requests, future development of qonsole will be done as part of the [qonsole-sfc](https://github.com/epimorphics/qonsole-sfc) project. (2022-07-04)_**
+A version of the [SPARQL qonsole](https://github.com/epimorphics/qonsole) that
+runs as a Rails engine
 
-A version of the [SPARQL qonsole](https://github.com/epimorphics/qonsole) that runs as a Rails engine
+> [!CAUTION]
+> While this project has not yet been replaced and should continue
+> to receive required bug fixes and any minor feature requests, future
+> development of qonsole will be done as part of the
+> [qonsole-sfc](https://github.com/epimorphics/qonsole-sfc) project.
+> (2022-07-04)
 
-## Installation
+---
 
-### Older versions of I.E:
+### Publishing the gem to the Epimorphics GitHub Package Registry (eGPR)[^1]
 
-Include 
+This gem is made available to the various HMLR applications via the eGPR.
 
-    <!--[if lt IE 9]>
-      <%= javascript_include_tag 'html5shiv-printshiv' %>
-    <![endif]-->
+Note that in order to publish to the eGPR, you'll need a GitHub Personal Access
+Token (PAT) with the appropriate permissions set.
 
-in the `head` of your HTML page.
+> [!TIP]
+> There are [instructions on the Epimorphics
+> wiki](https://github.com/epimorphics/internal/wiki/Ansible-CICD#creating-a-pat-for-gpr-access)
+> for creating a new PAT if you don't have one.
+> Once created, you can use the same PAT in multiple projects, you don't need to
+> create a new one each time.
+
+#### Publishing an updated version of the gem is then a manual process
+
+1. Make the required code changes, and have them reviewed by other members of
+   the team
+2. Update [`CHANGELOG.md`](/CHANGELOG.md) with the changes made
+3. Update the proper version cadence found in the
+   [`lib/qonsole_rails/version.rb`](/lib/qonsole_rails/version.rb)
+   following [semantic versioning principles](https://semver.org/)
+4. Check that the gem builds correctly locally by running the command: `make
+   gem` in a terminal window
+5. Visit the [project
+   repository](https://github.com/epimorphics/qonsole-rails), navigate to the
+   "[Actions](https://github.com/epimorphics/qonsole-rails/actions)" tab, and
+   select the "Release and Publish Gem" workflow from the listing on the left
+    - Click the "Run workflow" button on the right top of the workflow runs
+      listing
+    - Choose the **_"primary"_** branch to run the workflow on
+    - Click the "Run workflow" button below the branch selection
+6. When the workflow has completed, check on the eGPR[^1] to see that the new
+   gem has been published successfully
+
+[^1]: <https://github.com/orgs/epimorphics/packages?repo_name=qonsole_rails>

--- a/qonsole_rails.gemspec
+++ b/qonsole_rails.gemspec
@@ -6,27 +6,34 @@ $LOAD_PATH.push File.expand_path('lib', __dir__)
 require 'qonsole_rails/version'
 
 # Describe your gem and declare its dependencies:
-Gem::Specification.new do |s|
-  s.name        = 'qonsole-rails'
-  s.version     = QonsoleRails::VERSION
-  s.authors     = ['Epimorphics Ltd', 'Ian Dickinson']
-  s.email       = ['info@epimorphics.com']
-  s.homepage    = 'https://github.com/epimorphics/qonsole-rails'
-  s.summary     = 'SPARQL Qonsole engine for Rails'
-  s.description = 'Rails engine providing a dynamic console for editing and running SPARQL queries'
+Gem::Specification.new do |spec|
+  spec.name        = 'qonsole-rails'
+  spec.version     = QonsoleRails::VERSION
+  spec.authors     = ['Epimorphics Ltd', 'Ian Dickinson']
+  spec.email       = ['info@epimorphics.com']
+  spec.homepage    = 'https://github.com/epimorphics/qonsole-rails'
+  spec.summary     = 'SPARQL Qonsole engine for Rails'
+  spec.description = 'Rails engine providing a dynamic console for editing and running SPARQL queries'
+  spec.license     = 'MIT'
 
-  s.files = Dir['{app,config,db,lib}/**/*', 'LICENSE', 'Rakefile', 'README.rdoc']
-  s.test_files = Dir['test/**/*']
+  # This gem will work with 3.3.5 or greater...
+  spec.required_ruby_version = '~> 3.3'
 
-  s.add_dependency 'rails'
+  spec.files = Dir['{app,config,db,lib}/**/*', 'LICENSE', 'Rakefile', 'README.rdoc']
 
-  s.add_dependency 'faraday'
-  s.add_dependency 'faraday-encoding'
-  s.add_dependency 'faraday_middleware'
-  s.add_dependency 'font-awesome-rails'
-  s.add_dependency 'haml-rails'
-  s.add_dependency 'jquery-datatables-rails'
-  s.add_dependency 'jquery-rails'
-  s.add_dependency 'lodash-rails'
-  s.add_dependency 'modulejs-rails'
+  spec.metadata['rubygems_mfa_required'] = 'true'
+
+  spec.add_dependency 'rails'
+
+  spec.add_dependency 'faraday'
+  spec.add_dependency 'faraday-encoding'
+  spec.add_dependency 'faraday_middleware'
+  spec.add_dependency 'font-awesome-rails'
+  spec.add_dependency 'haml-rails'
+  spec.add_dependency 'jquery-datatables-rails'
+  spec.add_dependency 'jquery-rails'
+  spec.add_dependency 'lodash-rails'
+  spec.add_dependency 'modulejs-rails'
+  spec.add_dependency 'rubocop'
+  spec.add_dependency 'rubocop-rails'
 end


### PR DESCRIPTION
To resolve having to update the latest `revision` hash on the landing page Gemfile.lock file in order to import the latest updates to Qonsole-rails, this PR introduces the Github workflows to allow manual publication as a gem to the Epimorphics registry.

- Added gem creation and publishing workflows for easier updates.
- Updated rubocop rules for better readability and style.
- Adjusted gemspec to meet new guidelines from rubocop linting.
- Implemented pre-commit and pre-push githooks for linting/testing.
- Revamped README with the latest info on the gem and publishing process.
