### PR TITLE
tests: Update test class to use IntegrationTest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,16 +3,13 @@
 Qonsole Rails is a Ruby-on-Rails engine for embedding the ability to display,
 edit and run SPARQL queries in a larger Rails app.
 
-# 2.1.0 - 2025-02
+## 2.0.0 - 2025-02
 
 - Added gem creation and publishing workflows for easier updates.
 - Updated rubocop rules for better readability and style.
 - Adjusted gemspec to meet new guidelines from rubocop linting.
 - Implemented pre-commit and pre-push githooks for linting/testing.
 - Revamped README with the latest info on the gem and publishing process.
-
-## 2.0.0 - 2025-01
-
 - Updated the error handling for the qonsole gem by ensuring that the proper
   error types are returned and handled accordingly
 - Updated the formatting for the error messages to be more user-friendly

--- a/test/controllers/qonsole_rails/qonsole_controller_test.rb
+++ b/test/controllers/qonsole_rails/qonsole_controller_test.rb
@@ -1,6 +1,6 @@
 require 'test_helper'
 
 module QonsoleRails
-  class QonsoleControllerTest < ActionController::TestCase
+  class QonsoleControllerTest < ActionDispatch::IntegrationTest
   end
 end


### PR DESCRIPTION
Switched the test class from ActionController::TestCase to ActionDispatch::IntegrationTest for better integration testing capabilities.
