### PR TITLE
Task: Release v2.0.1

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -25,10 +25,11 @@ if [ -z "$RUBY_FILES" ]; then
   printf '\n\033[0;31mThere are currently no updated files in "%s". 🤨\033[0m\n' "$BRANCH_NAME"
 fi
 
-
 if [ -n "$RUBY_FILES" ]; then
   printf '\n\033[0;33mRunning Rubocop...\033[0m\n'
-  bundle exec rubocop --autocorrect "$RUBY_FILES"
+  for file in $RUBY_FILES; do
+    git show :"$file" | bundle exec rubocop -A --stdin "$file"
+  done
   RUBOCOP_EXIT_CODE=$?
   WORK_DONE=1
 else

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,36 @@
 Qonsole Rails is a Ruby-on-Rails engine for embedding the ability to display,
 edit and run SPARQL queries in a larger Rails app.
 
+## 2.0.1 - 2025-02
+
+- fix: adjusted un-used modal attributes
+  - Removed unnecessary aria-labelledby attribute from the modal.
+- build: Update gem dependencies and versions
+  - Renamed `qonsole-rails` to `qonsole_rails`
+  - Updated `date` gem from 3.3.4 to 3.4.1
+  - Upgraded several gems:
+    - `faraday-multipart` from 1.0.4 to 1.1.0
+    - `net-imap` from 0.4.17 to 0.5.5
+    - `net-smtp` from 0.5.0 to 0.5.1
+    - `nio4r` from 2.7.3 to 2.7.4
+    - `parser` from 3.3.7.0 to 3.3.7.1
+  - Updated other gems like `ffi`, `font-awesome-rails`, and more
+
+- style: Add new styles for layout and prefix elements
+  - Introduced a `.mx-auto` class for centering elements.
+  - Added styling for `.prefix` to adjust padding and input margins.
+  - Updated label styles within the `.prefix` class.
+- fix: Refactor button layout in vertical view
+  - Moved the submit button inside the label for better semantics.
+  - Cleaned up unnecessary HTML elements to simplify structure.
+- feat: Add visual hints for dropdown selections
+  - Added visually hidden text to indicate the currently selected endpoint.
+  - Included descriptions for each display format option in the dropdowns.
+  - Enhanced accessibility by providing context for users on what is currently selected.
+- refactor: Update copyright notice
+  - Included current year in copyright statement.
+  - Updated existing copyright text for clarity.
+
 ## 2.0.0 - 2025-02
 
 - Added gem creation and publishing workflows for easier updates.

--- a/Gemfile
+++ b/Gemfile
@@ -13,4 +13,6 @@ group :development, :test do
   gem 'byebug'
   gem 'minitest-rails'
   gem 'minitest-spec-rails'
+  gem 'rubocop'
+  gem 'rubocop-rails'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    qonsole_rails (2.0.0)
+    qonsole_rails (2.0.1)
       faraday
       faraday-encoding
       faraday_middleware
@@ -128,7 +128,16 @@ GEM
     faraday-retry (1.0.3)
     faraday_middleware (1.2.1)
       faraday (~> 1.0)
+    ffi (1.17.1-aarch64-linux-gnu)
+    ffi (1.17.1-aarch64-linux-musl)
+    ffi (1.17.1-arm-linux-gnu)
+    ffi (1.17.1-arm-linux-musl)
+    ffi (1.17.1-arm64-darwin)
+    ffi (1.17.1-x86-linux-gnu)
+    ffi (1.17.1-x86-linux-musl)
     ffi (1.17.1-x86_64-darwin)
+    ffi (1.17.1-x86_64-linux-gnu)
+    ffi (1.17.1-x86_64-linux-musl)
     font-awesome-rails (4.7.0.9)
       railties (>= 3.2, < 9.0)
     globalid (1.2.1)
@@ -340,6 +349,8 @@ DEPENDENCIES
   minitest-rails
   minitest-spec-rails
   qonsole_rails!
+  rubocop
+  rubocop-rails
 
 BUNDLED WITH
    2.5.20

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    qonsole-rails (2.0.0)
+    qonsole_rails (2.0.0)
       faraday
       faraday-encoding
       faraday_middleware
@@ -98,7 +98,7 @@ GEM
     concurrent-ruby (1.3.5)
     connection_pool (2.5.0)
     crass (1.0.6)
-    date (3.3.4)
+    date (3.4.1)
     drb (2.2.1)
     erubi (1.13.1)
     faraday (1.10.4)
@@ -119,8 +119,8 @@ GEM
       faraday
     faraday-excon (1.1.0)
     faraday-httpclient (1.0.1)
-    faraday-multipart (1.0.4)
-      multipart-post (~> 2)
+    faraday-multipart (1.1.0)
+      multipart-post (~> 2.0)
     faraday-net_http (1.0.2)
     faraday-net_http_persistent (1.2.0)
     faraday-patron (1.0.0)
@@ -128,18 +128,9 @@ GEM
     faraday-retry (1.0.3)
     faraday_middleware (1.2.1)
       faraday (~> 1.0)
-    ffi (1.17.0-aarch64-linux-gnu)
-    ffi (1.17.0-aarch64-linux-musl)
-    ffi (1.17.0-arm-linux-gnu)
-    ffi (1.17.0-arm-linux-musl)
-    ffi (1.17.0-arm64-darwin)
-    ffi (1.17.0-x86-linux-gnu)
-    ffi (1.17.0-x86-linux-musl)
-    ffi (1.17.0-x86_64-darwin)
-    ffi (1.17.0-x86_64-linux-gnu)
-    ffi (1.17.0-x86_64-linux-musl)
-    font-awesome-rails (4.7.0.8)
-      railties (>= 3.2, < 8.0)
+    ffi (1.17.1-x86_64-darwin)
+    font-awesome-rails (4.7.0.9)
+      railties (>= 3.2, < 9.0)
     globalid (1.2.1)
       activesupport (>= 6.1)
     haml (6.3.0)
@@ -192,16 +183,16 @@ GEM
     modulejs-rails (2.2.0.0)
       railties (>= 4.0)
     multipart-post (2.4.1)
-    net-imap (0.4.17)
+    net-imap (0.5.5)
       date
       net-protocol
     net-pop (0.1.2)
       net-protocol
     net-protocol (0.2.2)
       timeout
-    net-smtp (0.5.0)
+    net-smtp (0.5.1)
       net-protocol
-    nio4r (2.7.3)
+    nio4r (2.7.4)
     nokogiri (1.18.2)
       mini_portile2 (~> 2.8.2)
       racc (~> 1.4)
@@ -222,7 +213,7 @@ GEM
     nokogiri (1.18.2-x86_64-linux-musl)
       racc (~> 1.4)
     parallel (1.26.3)
-    parser (3.3.7.0)
+    parser (3.3.7.1)
       ast (~> 2.4.1)
       racc
     psych (5.1.2)
@@ -313,8 +304,8 @@ GEM
     stringio (3.1.1)
     temple (0.10.3)
     thor (1.3.2)
-    tilt (2.4.0)
-    timeout (0.4.1)
+    tilt (2.6.0)
+    timeout (0.4.3)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
     unicode-display_width (3.1.4)
@@ -322,7 +313,8 @@ GEM
     unicode-emoji (4.0.4)
     useragent (0.16.11)
     webrick (1.8.2)
-    websocket-driver (0.7.6)
+    websocket-driver (0.7.7)
+      base64
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
     zeitwerk (2.7.0)
@@ -347,7 +339,7 @@ DEPENDENCIES
   byebug
   minitest-rails
   minitest-spec-rails
-  qonsole-rails!
+  qonsole_rails!
 
 BUNDLED WITH
    2.5.20

--- a/app/assets/stylesheets/qonsole_rails/_qonsole.scss
+++ b/app/assets/stylesheets/qonsole_rails/_qonsole.scss
@@ -2,12 +2,30 @@
   font-size: 14px;
   margin-top: 2em;
 
+  .mx-auto {
+    display: inline-block;
+    margin-inline: auto;
+    width: fit-content;
+  }
+
   h2, .query-chrome label {
     font-size: 10px;
     color: #666666;
     margin: 0;
     text-transform: uppercase;
     display: inline-block;
+    font-weight: normal;
+  }
+
+  .prefix {
+    padding-top: 0.5em;
+  }
+
+  .prefix input {
+    margin-left: 0.5em;
+  }
+
+  .prefix label {
     font-weight: normal;
   }
 

--- a/app/assets/stylesheets/qonsole_rails/_qonsole.scss
+++ b/app/assets/stylesheets/qonsole_rails/_qonsole.scss
@@ -7,30 +7,80 @@
     margin-inline: auto;
     width: fit-content;
   }
+  h2 {
+    line-height: 2;
+  }
 
   h2, .query-chrome label {
     font-size: 10px;
     color: #666666;
     margin: 0;
     text-transform: uppercase;
-    display: inline-block;
+    display: block;
     font-weight: normal;
   }
 
-  .prefix {
-    padding-top: 0.5em;
-  }
+  .examples {
+    display: inline-flex;
+    justify-content: space-between;
+    width: 100%;
+    flex-wrap: wrap;
 
-  .prefix input {
-    margin-left: 0.5em;
-  }
+    @media (max-width: 32em) {
+      flex-direction: column;
+      > li {
+        width: 100%;
+        input.btn {
+          display: block;
+          width: 100%;
+        }
+      }
+    }
 
-  .prefix label {
-    font-weight: normal;
+    input.btn {
+      border: 1px solid #ddd;
+      &.active,
+      &:active,
+      &:focus,
+      &:hover {
+        border: 1px solid #ccc;
+        -webkit-box-shadow: inset 0 3px 5px rgba(0, 0, 0, 0.125);
+        box-shadow: inset 0 3px 5px rgba(0, 0, 0, 0.125);
+      }
+    }
   }
 
   .well {
     padding: 5px;
+
+    &.vertical {
+      line-height: 2;
+      h2 {
+        display: inline-block;
+        margin-right: 1em;
+      }
+      input {
+        &.form-control {
+          height: unset;
+          &.checkbox {
+            margin-right: 0.5rem;
+          }
+        }
+      }
+
+      .prefixes {
+        margin-left: 1rem;
+        .prefix {
+          input {
+            margin-left: 0.5em;
+            margin-right: 0.25rem;
+          }
+          label {
+            font-weight: normal;
+          }
+        }
+      }
+    }
 
     ul {
       margin-bottom: 0;
@@ -48,6 +98,29 @@
 
   .query-chrome {
     margin-top: 1em;
+    .row {
+      display: inline-flex;
+      justify-content: space-between;
+      align-items: flex-end;
+      gap: 1rem;
+      width: 100%;
+      margin-inline: unset;
+      @media(max-width: 44em) {
+        flex-wrap: wrap;
+        label {
+          width: 50%;
+        }
+      }
+      @media (max-width: 22em) {
+        flex-direction: column;
+      }
+
+      .form-group {
+        @media (min-width: 44em) {
+          text-align: end;
+        }
+      }
+    }
   }
 
   .timeTaken {
@@ -66,19 +139,6 @@
 
   a.run-query {
     margin-left: 10px;
-  }
-
-  .prefixes {
-    margin-left: 1rem;
-
-    label {
-      font-weight: normal;
-      margin: 0.75rem;
-
-      input {
-        margin-right: 0.25rem;
-      }
-    }
   }
 
   .auto-overflow {

--- a/app/assets/stylesheets/qonsole_rails/application.scss
+++ b/app/assets/stylesheets/qonsole_rails/application.scss
@@ -1,7 +1,6 @@
-@import
-  "font-awesome",
-  "codemirror",
-  "codemirror_adjust",
-  "dataTables/jquery.dataTables",
-  "datatables_fontawesome_adjust",
-  "qonsole";
+@import 'font-awesome';
+@import 'codemirror';
+@import 'codemirror_adjust';
+@import 'dataTables/jquery.dataTables';
+@import 'datatables_fontawesome_adjust';
+@import 'qonsole';

--- a/app/helpers/qonsole_rails/qonsole_helper.rb
+++ b/app/helpers/qonsole_rails/qonsole_helper.rb
@@ -16,6 +16,7 @@ module QonsoleRails
         config.prefixes.each do |prefix, uri|
           concat render_checkbox(prefix, uri)
         end
+        # concat render_prefix_editor_button
       end
     end
 
@@ -45,16 +46,32 @@ module QonsoleRails
     def render_checkbox(label, uri, options = {}) # rubocop:disable Metrics/MethodLength
       capture do
         concat(
-          content_tag('label') do
-            concat tag.input(
-              class: 'checkbox',
-              type: 'checkbox',
-              value: uri,
-              checked: true,
-              data: { query: options['data-query'] }
-            )
-            concat " #{label}"
+          content_tag('li', class: 'prefix') do
+            content_tag('label') do
+              concat tag.input(
+                class: 'checkbox',
+                type: 'checkbox',
+                value: uri,
+                checked: true,
+                data: { query: options['data-query'] }
+              )
+              concat " #{label}"
+            end
           end
+        )
+      end
+    end
+
+    def render_prefix_editor_button # rubocop:disable Metrics/MethodLength
+      content_tag('li', class: 'keep') do
+        concat tag.a(
+          tag.i(class: 'fa fa-plus-circle'),
+          class: 'btn btn-sm btn-default',
+          title: 'Add a SPARQL prefix',
+          data: {
+            toggle: 'modal',
+            target: '#prefixEditor'
+          }
         )
       end
     end

--- a/app/services/qonsole_rails/sparql_query_service.rb
+++ b/app/services/qonsole_rails/sparql_query_service.rb
@@ -47,7 +47,7 @@ module QonsoleRails
     end
 
     def create_connection(http_url)
-      Rails.logger.info("Connecting to #{http_url}")
+      Rails.logger.debug { "Connecting to #{http_url}" }
 
       with_connection_timeout(create_http_connection(http_url))
     end

--- a/app/views/qonsole_rails/qonsole/_qonsole_vertical.html.haml
+++ b/app/views/qonsole_rails/qonsole/_qonsole_vertical.html.haml
@@ -72,11 +72,9 @@
                   %span.hidden
                     (display results as SPARQL XML)
         .form-group.col-md-3
-          %label
-            &nbsp;
-            %br
           %br
-          %input.btn.btn-success.run-query{:href => "#", type: :submit, value: "perform query"}
+          %label
+            %input.btn.btn-success.run-query{:href => "#", type: :submit, value: "perform query"}
 
   #results-block.row.sparql.sparql-results
     .col-md-12

--- a/app/views/qonsole_rails/qonsole/_qonsole_vertical.html.haml
+++ b/app/views/qonsole_rails/qonsole/_qonsole_vertical.html.haml
@@ -1,6 +1,7 @@
 - content_for(:title, 'SPARQL Query Console')
+/
+  = "Copyright (c) 2012-#{Time.current.year} Epimorphics Ltd. Released under Apache License 2.0 http://www.apache.org/licenses/"
 
-/ Copyright (c) 2012-2014 Epimorphics Ltd. Released under Apache License 2.0 http://www.apache.org/licenses/
 %form.qonsole.form-inline{:role => "form", action: qonsole_rails.query_path}
   .col-md-12.well
     %h2 Example queries

--- a/app/views/qonsole_rails/qonsole/_qonsole_vertical.html.haml
+++ b/app/views/qonsole_rails/qonsole/_qonsole_vertical.html.haml
@@ -22,24 +22,21 @@
 
     .query-chrome
       .row
-        .form-group.col-md-2
-          %label{:for => "sparqlEndpoint"} &nbsp;
+        .form-group.col-lg-2
           .dropdown
             %a.btn.btn-dropdown{"data-toggle" => "dropdown", :href => "#"}
               Select endpoint
               %span#dropdownMenu1.visuallyhidden
                 , currently
                 = @qconfig.default_endpoint
-              %i.icon-collapse
+              %i{class: "fa fa-caret-down", "aria-hidden" => "true"}
             %ul.dropdown-menu.endpoints{"aria-labelledby" => "dropdownMenu1", :role => "menu"}
               = render_endpoints( @qconfig )
-        .form-group.col-md-5
-          .col-sm-8
-            %label{:for => "sparqlEndpoint"} SPARQL endpoint
-          %br
-          .col-xs-12
-            %input#sparqlEndpoint.form-control{:type => "text", style: "width: 100%", value: @qconfig.default_endpoint}/
-        .form-group.col-md-2
+        .form-group.col-lg-5
+          %label{:for => "sparqlEndpoint"}
+            SPARQL endpoint
+          %input#sparqlEndpoint.form-control{:type => "url", style: "width: 100%", value: @qconfig.default_endpoint, "autocomplete" => false}/
+        .form-group.col-lg-2
           %label{:for => "displayFormat"}
             Results
             %span#dropdownMenu2.visuallyhidden
@@ -47,34 +44,24 @@
               = "table"
             %br
           .dropdown
-            %a.btn.btn-dropdown.display-format{"data-toggle" => "dropdown", "data-value" => "tsv", :href => "#"}
+            %a.btn.btn-dropdown.display-format{"data-toggle" => "dropdown", "data-value" => "tsv", :href => "#", :role => "button", :id => "displayFormat"}
               %span table
-              %i.icon-collapse
+              %i{class: "fa fa-caret-down", "aria-hidden" => "true"}
             %ul.dropdown-menu.formats{"aria-labelledby" => "dropdownMenu2", :role => "menu"}
               %li{:role => "presentation"}
-                %a{"data-value" => "tsv", :href => "#", :role => "menuitem", :tabindex => "-1"}
+                %a{:data => {"value" => "tsv"}, :href => "#", :role => "menuitem", :tabindex => "-1", :title => "display results as tab-separated values"}
                   table
-                  %span.hidden
-                    (display results as tab-separated values)
               %li{:role => "presentation"}
-                %a{"data-value" => "text", :href => "#", :role => "menuitem", :tabindex => "-1"}
+                %a{"data-value" => "text", :href => "#", :role => "menuitem", :tabindex => "-1", :title => "display results as SPARQL text"}
                   plain text
-                  %span.hidden
-                    (display results as SPARQL text)
               %li{:role => "presentation"}
-                %a{"data-value" => "json", :href => "#", :role => "menuitem", :tabindex => "-1"}
+                %a{"data-value" => "json", :href => "#", :role => "menuitem", :tabindex => "-1", :title => "display results as SPARQL JSON"}
                   JSON
-                  %span.hidden
-                    (display results as SPARQL JSON)
               %li{:role => "presentation"}
-                %a{"data-value" => "xml", :href => "#", :role => "menuitem", :tabindex => "-1"}
+                %a{"data-value" => "xml", :href => "#", :role => "menuitem", :tabindex => "-1", :title => "display results as SPARQL XML"}
                   XML
-                  %span.hidden
-                    (display results as SPARQL XML)
-        .form-group.col-md-3
-          %br
-          %label
-            %input.btn.btn-success.run-query{:href => "#", type: :submit, value: "perform query"}
+        .form-group.col-lg-3
+          %input.btn.btn-success.run-query{type: :submit, value: "perform query"}
 
   #results-block.row.sparql.sparql-results
     .col-md-12

--- a/app/views/qonsole_rails/qonsole/_qonsole_vertical.html.haml
+++ b/app/views/qonsole_rails/qonsole/_qonsole_vertical.html.haml
@@ -27,6 +27,9 @@
           .dropdown
             %a.btn.btn-dropdown{"data-toggle" => "dropdown", :href => "#"}
               Select endpoint
+              %span#dropdownMenu1.visuallyhidden
+                , currently
+                = @qconfig.default_endpoint
               %i.icon-collapse
             %ul.dropdown-menu.endpoints{"aria-labelledby" => "dropdownMenu1", :role => "menu"}
               = render_endpoints( @qconfig )
@@ -39,6 +42,9 @@
         .form-group.col-md-2
           %label{:for => "displayFormat"}
             Results
+            %span#dropdownMenu2.visuallyhidden
+              , currently displayed as
+              = "table"
             %br
           .dropdown
             %a.btn.btn-dropdown.display-format{"data-toggle" => "dropdown", "data-value" => "tsv", :href => "#"}
@@ -46,13 +52,25 @@
               %i.icon-collapse
             %ul.dropdown-menu.formats{"aria-labelledby" => "dropdownMenu2", :role => "menu"}
               %li{:role => "presentation"}
-                %a{"data-value" => "tsv", :href => "#", :role => "menuitem", :tabindex => "-1"} table
+                %a{"data-value" => "tsv", :href => "#", :role => "menuitem", :tabindex => "-1"}
+                  table
+                  %span.hidden
+                    (display results as tab-separated values)
               %li{:role => "presentation"}
-                %a{"data-value" => "text", :href => "#", :role => "menuitem", :tabindex => "-1"} plain text
+                %a{"data-value" => "text", :href => "#", :role => "menuitem", :tabindex => "-1"}
+                  plain text
+                  %span.hidden
+                    (display results as SPARQL text)
               %li{:role => "presentation"}
-                %a{"data-value" => "json", :href => "#", :role => "menuitem", :tabindex => "-1"} JSON
+                %a{"data-value" => "json", :href => "#", :role => "menuitem", :tabindex => "-1"}
+                  JSON
+                  %span.hidden
+                    (display results as SPARQL JSON)
               %li{:role => "presentation"}
-                %a{"data-value" => "xml", :href => "#", :role => "menuitem", :tabindex => "-1"} XML
+                %a{"data-value" => "xml", :href => "#", :role => "menuitem", :tabindex => "-1"}
+                  XML
+                  %span.hidden
+                    (display results as SPARQL XML)
         .form-group.col-md-3
           %label
             &nbsp;

--- a/app/views/qonsole_rails/qonsole/_qonsole_vertical.html.haml
+++ b/app/views/qonsole_rails/qonsole/_qonsole_vertical.html.haml
@@ -89,7 +89,7 @@
             %h2.col-md-12 Query results
 
 / modal dialogue
-#prefixEditor.modal.fade{"aria-hidden" => "true", "aria-labelledby" => "myModalLabel", :role => "dialog", :tabindex => "-1"}
+#prefixEditor.modal.fade{"aria-hidden" => "true", :role => "dialog", :tabindex => "-1"}
   .modal-dialog
     .modal-content
       .modal-header

--- a/lib/qonsole_rails.rb
+++ b/lib/qonsole_rails.rb
@@ -3,17 +3,16 @@
 # Load the Rails engine
 require 'qonsole_rails/engine'
 
-# We do load the gem dependencies here because this is a gem,
-# not a bundle per-se
-require 'haml-rails'
+# We do load the gem dependencies here because this is a gem, not a bundle per-se
 require 'rails'
-require 'jquery-rails'
-require 'font-awesome-rails'
-require 'modulejs-rails'
-require 'lodash-rails'
 require 'faraday'
 require 'faraday_middleware'
+require 'font-awesome-rails'
+require 'haml-rails'
 require 'jquery-datatables-rails'
+require 'jquery-rails'
+require 'lodash-rails'
+require 'modulejs-rails'
 
 # :nodoc:
 module QonsoleRails

--- a/lib/qonsole_rails/version.rb
+++ b/lib/qonsole_rails/version.rb
@@ -1,6 +1,6 @@
 module QonsoleRails
   MAJOR = 2
   MINOR = 0
-  PATCH = 0
+  PATCH = 1
   VERSION = "#{MAJOR}.#{MINOR}.#{PATCH}".freeze
 end

--- a/qonsole_rails.gemspec
+++ b/qonsole_rails.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |spec|
   spec.homepage    = 'https://github.com/epimorphics/qonsole-rails'
   spec.summary     = 'SPARQL Qonsole engine for Rails'
   spec.description = 'Rails engine providing a dynamic console for editing and running SPARQL queries'
-  spec.license     = 'MIT'
+  spec.license     = 'Apache-2.0'
 
   # This gem will work with 3.3.5 or greater...
   spec.required_ruby_version = '~> 3.3'


### PR DESCRIPTION
This PR brings further updates to the gem for release and use in the associated applications:

- Adjusted unused modal attributes by removing unnecessary aria-labelledby.
- Updated gem dependencies, including renaming and upgrading several gems.
- Added new styles for layout with a `.mx-auto` class and improved `.prefix` styling.
- Refactored button layout in vertical view for better semantics.
- Introduced visual hints for dropdown selections to enhance accessibility.
- Updated copyright notice to reflect the current year and improve clarity.