### PR TITLE
fixes dropdown menu styles

### DIFF
--- a/app/assets/stylesheets/qonsole_rails/_qonsole.scss
+++ b/app/assets/stylesheets/qonsole_rails/_qonsole.scss
@@ -115,6 +115,12 @@
         .label-endpoint {
           font-size: 12px;
         }
+        [role=menuitem]{
+          font-size: calc(1.0rem + 0.4rem);
+          padding: 0.6rem 1.2rem;
+          white-space: nowrap;
+          width: 100%;
+        }
         @media(max-width: 44em) {
           flex-direction: column;
           gap: 1.5rem;

--- a/app/views/qonsole_rails/qonsole/_qonsole_vertical.html.haml
+++ b/app/views/qonsole_rails/qonsole/_qonsole_vertical.html.haml
@@ -46,7 +46,7 @@
             SPARQL endpoint
           %input#sparqlEndpoint.form-control{:type => "url", style: "width: 100%", value: @qconfig.default_endpoint, autocomplete: "off", "aria-describedby" => "endpointHelp"}
           %p#endpointHelp
-          Enter the full URL of the SPARQL endpoint you want to query.
+            Enter the full URL of the SPARQL endpoint you want to query.
 
         .query-item.results
           %label.label-results{:for => "sparqlFormat"}


### PR DESCRIPTION
This PR fixed the font size and styles of the drop-down menus on the SPARQL editor page.

<img width="1458" height="360" alt="Screenshot from 2026-02-16 15-38-23" src="https://github.com/user-attachments/assets/60e4e6de-dc8f-499f-bf58-6257fb7d5ffd" />
